### PR TITLE
Ignore non-pnr lines in mock data files

### DIFF
--- a/bin/bin.js
+++ b/bin/bin.js
@@ -20,6 +20,7 @@ if (program.args.length !== 1) {
   program.outputHelp();
 }
 
+console.time("pnr-scan");
 const directory = path.join(process.cwd(), program.args[0]);
 Finder.findPnrs(directory, program.pattern).forEach(item => {
   console.log(item.file);
@@ -27,3 +28,4 @@ Finder.findPnrs(directory, program.pattern).forEach(item => {
     console.log(`    ${hit.pnr} on line ${hit.line}`);
   });
 });
+console.timeEnd("pnr-scan");

--- a/lib/mockValidator.js
+++ b/lib/mockValidator.js
@@ -4,16 +4,16 @@ const Pnr = require(`./pnr`);
 
 const basePath = path.join(__dirname, `../`, `mocks`);
 
-let _mockNumbers = [];
+let mockNumbers = [];
 
 class Validator {
   static isMock(pnr) {
     this._populateMockData();
-    return _mockNumbers.includes(Pnr.normalizePnr(pnr));
+    return mockNumbers.includes(Pnr.normalizePnr(pnr));
   }
 
   static _populateMockData() {
-    if (_mockNumbers.length === 0) {
+    if (mockNumbers.length === 0) {
       const files = fs.readdirSync(basePath);
       files.forEach(file => {
         const mocks = fs
@@ -21,13 +21,9 @@ class Validator {
           .split(`\r\n`)
           .filter(line => Pnr.isValidPnr(line));
 
-        _mockNumbers = [..._mockNumbers, ...mocks];
+        mockNumbers = [...mockNumbers, ...mocks];
       });
     }
-  }
-
-  static set mockNumbers(mockNumbers) {
-    _mockNumbers = mockNumbers;
   }
 }
 

--- a/lib/mockValidator.js
+++ b/lib/mockValidator.js
@@ -4,27 +4,30 @@ const Pnr = require(`./pnr`);
 
 const basePath = path.join(__dirname, `../`, `mocks`);
 
-let mockNumbers = [];
+let _mockNumbers = [];
 
 class Validator {
   static isMock(pnr) {
     this._populateMockData();
-    return mockNumbers.includes(Pnr.normalizePnr(pnr));
+    return _mockNumbers.includes(Pnr.normalizePnr(pnr));
   }
 
   static _populateMockData() {
-    if (mockNumbers.length === 0) {
+    if (_mockNumbers.length === 0) {
       const files = fs.readdirSync(basePath);
       files.forEach(file => {
-        if (true) {
-          // TODO: remove headers
-          const mocks = fs
-            .readFileSync(path.join(basePath, file), `utf8`)
-            .split(`\r\n`);
-          mockNumbers = [...mockNumbers, ...mocks];
-        }
+        const mocks = fs
+          .readFileSync(path.join(basePath, file), `utf8`)
+          .split(`\r\n`)
+          .filter(line => Pnr.isValidPnr(line));
+
+        _mockNumbers = [..._mockNumbers, ...mocks];
       });
     }
+  }
+
+  static set mockNumbers(mockNumbers) {
+    _mockNumbers = mockNumbers;
   }
 }
 

--- a/lib/mockValidator.test.js
+++ b/lib/mockValidator.test.js
@@ -1,0 +1,29 @@
+const mockData = ["Testpersonnummer", "201710022383", "201801202381"].join(
+  "\r\n"
+);
+const mockFs = {
+  readdirSync: jest.fn(() => ["/some-path"]),
+  readFileSync: jest.fn(data => mockData)
+};
+jest.mock("fs", () => mockFs);
+
+const Validator = require(`./mockValidator`);
+
+describe(`Validator`, () => {
+  describe(`isMock()`, () => {
+    test(`returns true if pnr is in mock data`, () => {
+      expect(Validator.isMock("201710022383")).toBeTruthy();
+      expect(Validator.isMock("201801202381")).toBeTruthy();
+    });
+
+    test(`returns false if pnr is not in mock data`, () => {
+      expect(Validator.isMock("201801012392")).toBeFalsy();
+    });
+  });
+
+  describe(`can filter out non-pnr lines from mock data`, () => {
+    test(`returns false if pnr is not in mock data`, () => {
+      expect(Validator.isMock("Testpersonnummer")).toBeFalsy();
+    });
+  });
+});


### PR DESCRIPTION
Minor improvement.
The first line of each mock data file is `Testpersonnummer`. With this fix those lines will not be included when checking if a pnr is a test pnr.