### PR TITLE
Use .gitignore to ignore files when scanning

### DIFF
--- a/lib/finder.js
+++ b/lib/finder.js
@@ -12,7 +12,8 @@ class Finder {
     const files = glob.sync(pattern || defaultPattern, {
       cwd: searchPath,
       absolute: true,
-      nodir: true
+      nodir: true,
+      ignore: this._getIgnoreGlobs(searchPath)
     });
     return files
       .map(file => {
@@ -39,6 +40,22 @@ class Finder {
       }
     }
     return results;
+  }
+
+  static _getIgnoreGlobs(searchPath) {
+    let ignores = [];
+    const pathToGitIgnore = `${searchPath}/.gitignore`;
+    if (fs.existsSync(pathToGitIgnore)) {
+      ignores = fs
+        .readFileSync(pathToGitIgnore)
+        .toString()
+        .split("\n")
+        .filter(line => line.length > 0 && !line.startsWith("#"));
+      ignores.forEach(function(part, index) {
+        ignores[index] = `**/${part}`;
+      });
+    }
+    return ignores;
   }
 }
 

--- a/lib/finder.test.js
+++ b/lib/finder.test.js
@@ -15,6 +15,7 @@ const mockFsData = {
 };
 
 const mockFs = {
+  existsSync: path => mockFsData.hasOwnProperty(path),
   readFileSync: jest.fn(data => mockFsData[data])
 };
 const mockIsTextOrBinary = {
@@ -64,5 +65,25 @@ describe(`getPnrsInFile`, () => {
   test(`Should not return mocked pnrs`, () => {
     const result = Finder.getPnrsInFile("/path/to/file5");
     expect(result.length).toBe(0);
+  });
+});
+
+describe(`_getIgnoreGlobs`, () => {
+  beforeEach(() => {
+    delete mockFsData["/path/.gitignore"];
+  });
+  test(`prepend **/ on each glob in .gitignore`, () => {
+    mockFsData["/path/.gitignore"] = "*.java";
+    const result = Finder._getIgnoreGlobs("/path");
+    expect(result).toEqual(expect.arrayContaining(["**/*.java"]));
+  });
+  test(`removes comments from .gitignore`, () => {
+    mockFsData["/path/.gitignore"] = "#comment";
+    const result = Finder._getIgnoreGlobs("/path");
+    expect(result).toEqual(expect.arrayContaining([]));
+  });
+  test(`return empty list if .gitignore does not exists`, () => {
+    const result = Finder._getIgnoreGlobs("/bogus");
+    expect(result).toEqual(expect.arrayContaining([]));
   });
 });


### PR DESCRIPTION
.gitignore is expected to be located in the root of `searchPath`, no other .gitignore will be parsed

Fixes #2