### PR TITLE
Added --fix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,3 @@ $ pnr-scanner .
     -p, --pattern <pattern>  Glob pattern default is !(node_modules){,/**}
     -h, --help               output usage information
 ```
-
-## Todo
-
-* Imporve `--fix` to select test data smarter. Perhaps with the same birth date.

--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ $ pnr-scanner .
 
 ## Todo
 
-* `--fix` - an option that helps the user to fix any real Swedish personal identity numbers with test data
+* Imporve `--fix` to select test data smarter. Perhaps with the same birth date.

--- a/bin/bin.js
+++ b/bin/bin.js
@@ -4,6 +4,7 @@ const pkg = require(`../package.json`);
 const program = require(`commander`);
 const path = require(`path`);
 const Finder = require(`../lib/finder`);
+const Fixer = require(`../lib/fixer`);
 
 program
   .version(pkg.version)
@@ -13,6 +14,7 @@ program
     `-p, --pattern <pattern>`,
     `Glob pattern default is !(node_modules){,/**}`
   )
+  .option(`-f, --fix`, `Replace real pnrs with test pnrs`)
   .parse(process.argv);
 
 if (program.args.length !== 1) {
@@ -22,10 +24,22 @@ if (program.args.length !== 1) {
 
 console.time("pnr-scan");
 const directory = path.join(process.cwd(), program.args[0]);
-Finder.findPnrs(directory, program.pattern).forEach(item => {
+const result = Finder.findPnrs(directory, program.pattern);
+console.timeEnd("pnr-scan");
+
+if (program.fix && result.length > 0) {
+  console.time("pnr-fix");
+  Fixer.fixPnrs(result);
+  console.timeEnd("pnr-fix");
+}
+
+result.forEach(item => {
   console.log(item.file);
   item.results.forEach(hit => {
-    console.log(`    ${hit.pnr} on line ${hit.line}`);
+    if (hit.replacement) {
+      console.log(`    ${hit.pnr} => ${hit.replacement} on line ${hit.line}`);
+    } else {
+      console.log(`    ${hit.pnr} on line ${hit.line}`);
+    }
   });
 });
-console.timeEnd("pnr-scan");

--- a/lib/fixer.js
+++ b/lib/fixer.js
@@ -1,0 +1,55 @@
+const Substitutor = require("./substitutor");
+const FileMockDataReader = require("./fileMockDataReader");
+const fs = require(`fs`);
+
+const substitutor = new Substitutor(FileMockDataReader.fetch());
+
+class Fixer {
+  static fixPnrs(finderResult) {
+    finderResult.forEach(item => {
+      let fileContent = fs.readFileSync(item.file, "utf8");
+      item.results.forEach(result => {
+        const realPnr = result.pnr;
+        let testPnr = substitutor.getReplacement(realPnr);
+        testPnr = Fixer.matchFormat(realPnr, testPnr);
+        fileContent = fileContent.replace(realPnr, testPnr);
+        result.replacement = testPnr;
+      });
+      fs.writeFileSync(item.file, fileContent, "utf8");
+    });
+  }
+
+  static matchFormat(pnrToMatch, testPnr) {
+    let realPnrBackwards = pnrToMatch
+      .slice()
+      .split("")
+      .reverse();
+    let testPnrBackwards = testPnr
+      .slice()
+      .split("")
+      .reverse();
+    let lastReplacedIndex = -1;
+    testPnrBackwards.forEach(char => {
+      let charHasBeenReplaced = false;
+      while (
+        !charHasBeenReplaced &&
+        lastReplacedIndex < realPnrBackwards.length
+      ) {
+        const nextIndexToReplace = lastReplacedIndex + 1;
+        if (Fixer.isCharDigit(realPnrBackwards[nextIndexToReplace])) {
+          realPnrBackwards[nextIndexToReplace] = char;
+          charHasBeenReplaced = true;
+        }
+        lastReplacedIndex = nextIndexToReplace;
+      }
+    });
+
+    return realPnrBackwards.reverse().join("");
+  }
+
+  static isCharDigit(char) {
+    return !!parseInt(char);
+  }
+}
+
+module.exports = Fixer;

--- a/lib/fixer.test.js
+++ b/lib/fixer.test.js
@@ -1,0 +1,78 @@
+const mockFs = {
+  writeFileSync: jest.fn(),
+  readFileSync: jest.fn()
+};
+jest.mock("fs", () => mockFs);
+
+const mockFileMockDataReader = {
+  fetch: jest.fn()
+};
+jest.mock("./fileMockDataReader", () => mockFileMockDataReader);
+
+const mockSubstitutor = {
+  getReplacement: jest.fn()
+};
+jest.mock("./substitutor", () => {
+  return jest.fn().mockImplementation(() => mockSubstitutor);
+});
+
+const Fixer = require("./fixer");
+
+describe("Fixer", () => {
+  test("overwrites file after replacment", () => {
+    mockFs.readFileSync = () => `file content`;
+    const finderResult = [
+      {
+        file: "file.js",
+        results: []
+      }
+    ];
+
+    Fixer.fixPnrs(finderResult);
+    expect(mockFs.writeFileSync).toBeCalledWith(
+      `file.js`,
+      expect.any(String),
+      expect.any(String)
+    );
+  });
+
+  test("replaces real prn with test data", () => {
+    mockFs.readFileSync = () => `Bogus pnr: "199999999999".`;
+    mockSubstitutor.getReplacement = () => "198888888888";
+    const finderResult = [
+      {
+        file: "file.js",
+        results: [
+          {
+            pnr: "199999999999"
+          }
+        ]
+      }
+    ];
+
+    Fixer.fixPnrs(finderResult);
+    expect(mockFs.writeFileSync).toBeCalledWith(
+      expect.any(String),
+      `Bogus pnr: "198888888888".`,
+      expect.any(String)
+    );
+  });
+
+  describe("matchFormat", () => {
+    test("can format with spaces", () => {
+      expect(Fixer.matchFormat("1 2 3", "789")).toBe("7 8 9");
+    });
+    test("can format with hyphen", () => {
+      expect(Fixer.matchFormat("12-3", "789")).toBe("78-9");
+    });
+    test("can format with plus", () => {
+      expect(Fixer.matchFormat("12+3", "789")).toBe("78+9");
+    });
+    test("can format with spaces and hypen", () => {
+      expect(Fixer.matchFormat("12 - 3", "789")).toBe("78 - 9");
+    });
+    test("can format with spaces and plus", () => {
+      expect(Fixer.matchFormat("12 + 3", "789")).toBe("78 + 9");
+    });
+  });
+});

--- a/lib/substitutor.js
+++ b/lib/substitutor.js
@@ -1,0 +1,27 @@
+const Pnr = require("./pnr");
+
+class Substitutor {
+  constructor(testPnrs) {
+    this.testPnrs = testPnrs;
+    this.prevSubstitutions = {};
+  }
+
+  /**
+   * Returns a random replacemennt PNR from the test data given to the constructor.
+   * This method will return the same replacement for the given `realPnr` over and over again.
+   * @param {String} realPnr
+   */
+  getReplacement(realPnr) {
+    const normalizedRealPnr = Pnr.normalizePnr(realPnr);
+    if (normalizedRealPnr in this.prevSubstitutions) {
+      return this.prevSubstitutions[normalizedRealPnr];
+    }
+
+    const i = Math.floor(Math.random() * (this.testPnrs.length - 1));
+    const testPnr = this.testPnrs[i];
+    this.prevSubstitutions[normalizedRealPnr] = testPnr;
+    return testPnr;
+  }
+}
+
+module.exports = Substitutor;

--- a/lib/substitutor.js
+++ b/lib/substitutor.js
@@ -2,25 +2,47 @@ const Pnr = require("./pnr");
 
 class Substitutor {
   constructor(testPnrs) {
-    this.testPnrs = testPnrs;
+    this.testPnrsWithTimestamp = testPnrs.sort().map(pnr => {
+      const date = this._parseDateFromPnr(pnr);
+      return {
+        pnr: pnr,
+        timestamp: date.getTime()
+      };
+    });
     this.prevSubstitutions = {};
   }
 
   /**
-   * Returns a random replacemennt PNR from the test data given to the constructor.
-   * This method will return the same replacement for the given `realPnr` over and over again.
-   * @param {String} realPnr
+   * Returns a replacemennt PNR from the test data given to the constructor. The date closest to the given PNR is returned.
+   * This method will return the same replacement for the given `pnr` over and over again.
+   * @param {String} pnr
    */
-  getReplacement(realPnr) {
-    const normalizedRealPnr = Pnr.normalizePnr(realPnr);
-    if (normalizedRealPnr in this.prevSubstitutions) {
-      return this.prevSubstitutions[normalizedRealPnr];
+  getReplacement(pnr) {
+    const normalizedPnr = Pnr.normalizePnr(pnr);
+    if (normalizedPnr in this.prevSubstitutions) {
+      return this.prevSubstitutions[normalizedPnr];
     }
 
-    const i = Math.floor(Math.random() * (this.testPnrs.length - 1));
-    const testPnr = this.testPnrs[i];
-    this.prevSubstitutions[normalizedRealPnr] = testPnr;
+    const testPnr = this._findReplacement(normalizedPnr);
+    this.prevSubstitutions[normalizedPnr] = testPnr;
     return testPnr;
+  }
+
+  _findReplacement(pnr) {
+    const targetTimestamp = this._parseDateFromPnr(pnr).getTime();
+    return this.testPnrsWithTimestamp.reduce(function(prev, curr) {
+      const currDistance = Math.abs(curr.timestamp - targetTimestamp);
+      const prevDistance = Math.abs(prev.timestamp - targetTimestamp);
+      return currDistance < prevDistance ? curr : prev;
+    }).pnr;
+  }
+
+  _parseDateFromPnr(pnr) {
+    return new Date(
+      pnr.substring(0, 4),
+      parseInt(pnr.substring(4, 6)) - 1,
+      pnr.substring(6, 8)
+    );
   }
 }
 

--- a/lib/substitutor.test.js
+++ b/lib/substitutor.test.js
@@ -14,4 +14,30 @@ describe("Substitutor", () => {
     substitutor.testPnrs = [];
     expect(substitutor.getReplacement("1")).toEqual(firstReplacement);
   });
+
+  test("shall pick pnr with same date", () => {
+    const substitutor = new Substitutor([
+      "20180610xxxx",
+      "20180611xxxx",
+      "20180612xxxx"
+    ]);
+    expect(substitutor.getReplacement("20180611yyyy")).toBe("20180611xxxx");
+  });
+
+  test("shall pick the earliest pnr if multiple dates are equally close", () => {
+    const substitutor = new Substitutor(["20180612xxxx", "20180610xxxx"]);
+    expect(substitutor.getReplacement("20180611yyyy")).toBe("20180610xxxx");
+  });
+
+  describe("shall pick pnr with closest date", () => {
+    test("crossing new year", () => {
+      const substitutor = new Substitutor(["20180131xxxx", "20171231xxxx"]);
+      expect(substitutor.getReplacement("20180101yyyy")).toBe("20171231xxxx");
+    });
+
+    test("crossing new month", () => {
+      const substitutor = new Substitutor(["20180610xxxx", "20180531xxxx"]);
+      expect(substitutor.getReplacement("20180601yyyy")).toBe("20180531xxxx");
+    });
+  });
 });

--- a/lib/substitutor.test.js
+++ b/lib/substitutor.test.js
@@ -1,0 +1,17 @@
+const Substitutor = require("./substitutor");
+
+describe("Substitutor", () => {
+  test("can pick a replacement test pnr", () => {
+    const substitutor = new Substitutor(["2"]);
+    expect(substitutor.getReplacement("1")).toBe("2");
+  });
+
+  test("shall return the same replacement over and over for a pnr", () => {
+    const substitutor = new Substitutor(["2"]);
+    const firstReplacement = substitutor.getReplacement("1");
+    expect(firstReplacement).toBe("2");
+
+    substitutor.testPnrs = [];
+    expect(substitutor.getReplacement("1")).toEqual(firstReplacement);
+  });
+});


### PR DESCRIPTION
The `--fix` option will pick the test PNR with a date as close as possible to the actual PNR. Then it will replace the actual PNR in all files with the same test PNR.

At last it will print which PNR was replaced by what and in which file.
Example usage and output:
```bash
$ ./bin/bin.js testdata --fix
pnr-scan: 6.391ms
pnr-fix: 14.463ms
/Users/andreas/dev/pnr-scanner/testdata/Pnr.java
    19121212  - 1212 => 19120211  - 9176 on line 2
    19121212+1212 => 19120211+9176 on line 3
    19121212-1212 => 19120211-9176 on line 4
    191212121212 => 191202119176 on line 5
    121212-1212 => 130101-2397 on line 6
    1212121212 => 1301012397 on line 7
    191212121212 => 191202119176 on line 8
    1212121212 => 1301012397 on line 9
    1212121212 => 1301012397 on line 13
    1212121212 => 1301012397 on line 17
    19121212-1212 => 19120211-9176 on line 20
```

Fixes: #11 